### PR TITLE
fix cypress 10 change - do not exit without cypress.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,8 +102,10 @@ Afterwards it will attach a report.html to this run and create an archive contai
 Argument                    | Description
 ------                      | ------
 `name`                      | The Name of your Testrail Run
+`projectId`                 | The ID of your Testrail Project
 `suiteId`                   | Testrails suite Id
 `reportFilename`            | The relative path to your report (from `process.cwd`).Example: `result.json`  Default: `testrailReporter.reportFilename`
+`branchReferenceRegex`      | This Reporter will create JIRA References if this regex is matching your Branch name
 `closeRun`                  | Whether to close the run automatically or not. Default: `false`
 `host`                      | The Address of your running Testrail Application (API)
 `username`                  | A Username for Authentication against Testrail API

--- a/src/helper/readConfig.ts
+++ b/src/helper/readConfig.ts
@@ -1,7 +1,7 @@
 import fs from 'fs'
 import { TestrailReporterConfig } from '../types'
 
-export default function readConfig(): TestrailReporterConfig | null {
+export default function readConfig(): TestrailReporterConfig | {} | null {
   try {
     const config = fs.readFileSync(`${process.cwd()}/cypress.json`, 'utf-8')
     const cypressConfig = JSON.parse(config)
@@ -13,7 +13,10 @@ export default function readConfig(): TestrailReporterConfig | null {
   } catch (e) {
     // eslint-disable-next-line no-console
     console.error(`No cypress.json config found at ${process.cwd()}`)
-    process.exit(1)
+    // do not exit because in cypress 10 is no cypress.json
+    // and CLI Arguments are possible
+    // process.exit(1)
+    return {};
   }
   return null
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,12 @@ yargs
     describe: 'Name of the Test Run',
     type: 'string',
   })
+  .option('projectId', {
+    demandOption: false,
+    describe: 'related Testrail Project Id',
+    type: 'string',
+    default: config?.projectId,
+  })
   .option('suiteId', {
     demandOption: false,
     describe: 'related Testrail Suite Id',
@@ -29,6 +35,12 @@ yargs
     describe: 'Cypress Result as json file - can also be defined within your cypress.json testrailReporter section',
     type: 'string',
     default: config?.reportFilename,
+  })
+  .option('branchReferenceRegex', {
+    demandOption: false,
+    describe: 'This Reporter will create JIRA References if this regex is matching your Branch name',
+    type: 'string',
+    default: config?.branchReferenceRegex || null,
   })
   .option('closeRun', {
     demandOption: false,
@@ -110,6 +122,8 @@ parseCypressResults(reportFilename)
           password: yargs.argv.password,
           host: yargs.argv.host,
           suiteId: yargs.argv.suiteId,
+          projectId: yargs.argv.projectId,
+          branchReferenceRegex: yargs.argv.branchReferenceRegex,
         },
         name,
         parsedTestResults.testRailCases,


### PR DESCRIPTION
With cypress 10 all config json files are js files, so no cypress.json exists.

As quick fix do not exit if no cypress.json found.